### PR TITLE
Add new key types

### DIFF
--- a/benches/art_bench.rs
+++ b/benches/art_bench.rs
@@ -13,7 +13,7 @@ pub fn modifications(c: &mut Criterion) {
         let mut tree = Art::new();
         let mut key = 0u64;
         b.iter(|| {
-            tree.insert(ByteString::from(key), key);
+            tree.insert(key, key);
             key += 1;
         })
     });
@@ -32,7 +32,7 @@ pub fn modifications(c: &mut Criterion) {
         let mut tree = Art::new();
         let mut key = 0u64;
         b.iter(|| {
-            tree.upsert(ByteString::from(key), key);
+            tree.upsert(key, key);
             key += 1;
         })
     });
@@ -51,11 +51,11 @@ pub fn modifications(c: &mut Criterion) {
         let mut tree = Art::new();
         b.iter_custom(|iters| {
             for i in 0..iters {
-                tree.insert(ByteString::from(i), i);
+                tree.insert(i, i);
             }
             let start = Instant::now();
             for i in 0..iters {
-                tree.remove(&ByteString::from(i));
+                tree.remove(&i);
             }
             start.elapsed()
         })
@@ -70,12 +70,12 @@ pub fn access(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("rand_get", size), &size, |b, size| {
             let mut tree = Art::new();
             for i in 0..*size {
-                tree.insert(ByteString::from(i), i);
+                tree.insert(i, i);
             }
             let mut rng = thread_rng();
             b.iter(|| {
                 let key = rng.gen_range(0..*size);
-                tree.get(&ByteString::from(key));
+                tree.get(&key);
             })
         });
     }
@@ -84,11 +84,11 @@ pub fn access(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("seq_get", size), &size, |b, size| {
             let mut tree = Art::new();
             for i in 0..*size {
-                tree.insert(ByteString::from(i), i);
+                tree.insert(i, i);
             }
             let mut key = 0u64;
             b.iter(|| {
-                tree.get(&ByteString::from(key));
+                tree.get(&key);
                 key += 1;
             })
         });
@@ -103,7 +103,7 @@ pub fn iter(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("iter_u64", size), &size, |b, size| {
             let mut tree = Art::new();
             for i in 0..*size {
-                tree.insert(ByteString::from(i), i);
+                tree.insert(i, i);
             }
             b.iter(|| {
                 tree.iter().count();

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -3,16 +3,20 @@ use std::mem;
 
 /// Trait represent [Art] key.
 /// Trait define method which convert key into byte comparable sequence. This sequence will be
-/// used to order keys inside tree. [Art] crate has several implementation of [Key] trait inside
-/// `keys` module.
+/// used to order keys inside tree.
 pub trait Key {
     /// Converts key to byte comparable sequence. This sequence used to represent key inside
     /// [Art] tree.
+    ///
+    /// ## Warning
+    /// Implementation must ensure that returned bytes vector have consistent order of bytes. E.g.
+    /// key type must have same ordering guarantees as returned byte sequence.  
+    /// For instance, if `"abc" < "def"`, then `"abc".to_bytes() < "def".to_bytes()`.
+    /// **Violation** of this rule is **undefined behaviour** and can cause `panic`.
     fn to_bytes(&self) -> Vec<u8>;
 }
 
-/// Implementation of [Key] which can represent basic primitive Rust types(`u32`, `&[u8]`, etc) as
-/// byte comparable sequence.
+/// Implementation of [Key] which wraps bytes slice.
 #[derive(Clone, PartialOrd, Ord, Debug)]
 #[repr(transparent)]
 pub struct ByteString {
@@ -38,6 +42,12 @@ impl Eq for ByteString {}
 impl PartialEq for ByteString {
     fn eq(&self, other: &Self) -> bool {
         self.bytes == other.bytes
+    }
+}
+
+impl Key for usize {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::mem;
 
@@ -29,6 +30,12 @@ impl ByteString {
         Self {
             bytes: bytes.to_vec(),
         }
+    }
+}
+
+impl Borrow<[u8]> for ByteString {
+    fn borrow(&self) -> &[u8] {
+        &self.bytes
     }
 }
 
@@ -151,6 +158,12 @@ pub struct Float32 {
     key: [u8; 4],
 }
 
+impl Borrow<[u8]> for Float32 {
+    fn borrow(&self) -> &[u8] {
+        &self.key
+    }
+}
+
 impl Eq for Float32 {}
 
 impl PartialEq<Float32> for Float32 {
@@ -187,6 +200,12 @@ impl From<f32> for Float32 {
 #[repr(transparent)]
 pub struct Float64 {
     key: [u8; 8],
+}
+
+impl Borrow<[u8]> for Float64 {
+    fn borrow(&self) -> &[u8] {
+        &self.key
+    }
 }
 
 impl Eq for Float64 {}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -16,7 +16,8 @@ pub trait Key {
     fn to_bytes(&self) -> Vec<u8>;
 }
 
-/// Implementation of [Key] which wraps bytes slice.
+/// Implementation of [Key] which wraps bytes slice. It can be used to represent strings as
+/// comparable byte sequence.
 #[derive(Clone, PartialOrd, Ord, Debug)]
 #[repr(transparent)]
 pub struct ByteString {
@@ -172,7 +173,6 @@ impl PartialOrd<Float32> for Float32 {
 
 impl From<f32> for Float32 {
     fn from(v: f32) -> Self {
-        assert!(v.is_normal());
         let v: u32 = v.to_bits();
         let xor = 1 << 31;
         let i = (v ^ xor) & xor;
@@ -211,7 +211,6 @@ impl PartialOrd<Float64> for Float64 {
 
 impl From<f64> for Float64 {
     fn from(v: f64) -> Self {
-        assert!(v.is_normal());
         let v: u64 = v.to_bits();
         let xor = 1 << 63;
         let i = (v ^ xor) & xor;
@@ -244,11 +243,13 @@ impl Key for Float64 {
 /// tree key.
 /// ```
 /// use art_tree::Art;
+/// use art_tree::KeyBuilder;
+/// use art_tree::ByteString;
 ///
 /// struct MyStruct(u8, String, u32, Box<f64>);
 ///
 /// let mut art = Art::new();
-/// let key = KeyBuilder::new().append(1).append("abc".to_string()).build();
+/// let key = KeyBuilder::new().append(1).append(ByteString::new("abc".to_string().as_bytes())).build();
 /// let val = MyStruct(1, "abc".to_string(), 200, Box::new(0.1));
 /// assert!(art.insert(key.clone(), val));
 /// assert!(art.get(&key).is_some());

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,4 +1,14 @@
-use crate::Key;
+use std::mem;
+
+/// Trait represent [Art] key.
+/// Trait define method which convert key into byte comparable sequence. This sequence will be
+/// used to order keys inside tree. [Art] crate has several implementation of [Key] trait inside
+/// `keys` module.
+pub trait Key: Eq + Ord {
+    /// Converts key to byte comparable sequence. This sequence used to represent key inside
+    /// [Art] tree.
+    fn to_bytes(&self) -> Vec<u8>;
+}
 
 /// Implementation of [Key] which can represent basic primitive Rust types(`u32`, `&[u8]`, etc) as
 /// byte comparable sequence.
@@ -66,5 +76,98 @@ impl From<u8> for ByteString {
         Self {
             bytes: val.to_be_bytes().to_vec(),
         }
+    }
+}
+
+impl Key for u8 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for u16 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for u32 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for u64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for u128 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for i8 {
+    fn to_bytes(&self) -> Vec<u8> {
+        // flip upper bit of signed value to get comparable byte sequence:
+        // -128 => 0
+        // -127 => 1
+        // 0 => 128
+        // 1 => 129
+        // 127 => 255
+        let v: u8 = unsafe { mem::transmute(*self) };
+        // flip upper bit and set to 0 other bits:
+        // (0000_1100 ^ 1000_0000) & 1000_0000 = 1000_0000
+        // (1000_1100 ^ 1000_0000) & 1000_0000 = 0000_0000
+        let i = (v ^ 0x80) & 0x80;
+        // repair bits(except upper bit) of value:
+        // self = -127
+        // i = 0 (0b0000_0000)
+        // v = 129 (0b1000_0001)
+        // j = 0b0000_0000 | (0b1000_0001 & 0b0111_1111) = 0b0000_0000 | 0b0000_0001 = 0b0000_0001 = 1
+        let j = i | (v & 0x7F);
+        j.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for i16 {
+    fn to_bytes(&self) -> Vec<u8> {
+        let v: u16 = unsafe { mem::transmute(*self) };
+        let xor = 1 << 15;
+        let i = (v ^ xor) & xor;
+        let j = i | (v & (u16::MAX >> 1));
+        j.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for i32 {
+    fn to_bytes(&self) -> Vec<u8> {
+        let v: u32 = unsafe { mem::transmute(*self) };
+        let xor = 1 << 31;
+        let i = (v ^ xor) & xor;
+        let j = i | (v & (u32::MAX >> 1));
+        j.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for i64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        let v: u64 = unsafe { mem::transmute(*self) };
+        let xor = 1 << 63;
+        let i = (v ^ xor) & xor;
+        let j = i | (v & (u64::MAX >> 1));
+        j.to_be_bytes().to_vec()
+    }
+}
+
+impl Key for i128 {
+    fn to_bytes(&self) -> Vec<u8> {
+        let v: u128 = unsafe { mem::transmute(*self) };
+        let xor = 1 << 127;
+        let i = (v ^ xor) & xor;
+        let j = i | (v & (u128::MAX >> 1));
+        j.to_be_bytes().to_vec()
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -278,6 +278,12 @@ pub struct KeyBuilder {
     key: ByteString,
 }
 
+impl Default for KeyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KeyBuilder {
     pub fn new() -> Self {
         Self {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,10 +1,11 @@
+use std::cmp::Ordering;
 use std::mem;
 
 /// Trait represent [Art] key.
 /// Trait define method which convert key into byte comparable sequence. This sequence will be
 /// used to order keys inside tree. [Art] crate has several implementation of [Key] trait inside
 /// `keys` module.
-pub trait Key: Eq + Ord {
+pub trait Key {
     /// Converts key to byte comparable sequence. This sequence used to represent key inside
     /// [Art] tree.
     fn to_bytes(&self) -> Vec<u8>;
@@ -13,6 +14,7 @@ pub trait Key: Eq + Ord {
 /// Implementation of [Key] which can represent basic primitive Rust types(`u32`, `&[u8]`, etc) as
 /// byte comparable sequence.
 #[derive(Clone, PartialOrd, Ord, Debug)]
+#[repr(transparent)]
 pub struct ByteString {
     bytes: Vec<u8>,
 }
@@ -36,46 +38,6 @@ impl Eq for ByteString {}
 impl PartialEq for ByteString {
     fn eq(&self, other: &Self) -> bool {
         self.bytes == other.bytes
-    }
-}
-
-impl From<u128> for ByteString {
-    fn from(val: u128) -> Self {
-        Self {
-            bytes: val.to_be_bytes().to_vec(),
-        }
-    }
-}
-
-impl From<u64> for ByteString {
-    fn from(val: u64) -> Self {
-        Self {
-            bytes: val.to_be_bytes().to_vec(),
-        }
-    }
-}
-
-impl From<u32> for ByteString {
-    fn from(val: u32) -> Self {
-        Self {
-            bytes: val.to_be_bytes().to_vec(),
-        }
-    }
-}
-
-impl From<u16> for ByteString {
-    fn from(val: u16) -> Self {
-        Self {
-            bytes: val.to_be_bytes().to_vec(),
-        }
-    }
-}
-
-impl From<u8> for ByteString {
-    fn from(val: u8) -> Self {
-        Self {
-            bytes: val.to_be_bytes().to_vec(),
-        }
     }
 }
 
@@ -169,5 +131,144 @@ impl Key for i128 {
         let i = (v ^ xor) & xor;
         let j = i | (v & (u128::MAX >> 1));
         j.to_be_bytes().to_vec()
+    }
+}
+
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+pub struct Float32 {
+    key: [u8; 4],
+}
+
+impl Eq for Float32 {}
+
+impl PartialEq<Float32> for Float32 {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl Ord for Float32 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+impl PartialOrd<Float32> for Float32 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.key.cmp(&other.key))
+    }
+}
+
+impl From<f32> for Float32 {
+    fn from(v: f32) -> Self {
+        assert!(v.is_normal());
+        let v: u32 = v.to_bits();
+        let xor = 1 << 31;
+        let i = (v ^ xor) & xor;
+        let j = i | (v & (u32::MAX >> 1));
+        Self {
+            key: j.to_be_bytes(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+pub struct Float64 {
+    key: [u8; 8],
+}
+
+impl Eq for Float64 {}
+
+impl PartialEq<Float64> for Float64 {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl Ord for Float64 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+impl PartialOrd<Float64> for Float64 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.key.cmp(&other.key))
+    }
+}
+
+impl From<f64> for Float64 {
+    fn from(v: f64) -> Self {
+        assert!(v.is_normal());
+        let v: u64 = v.to_bits();
+        let xor = 1 << 63;
+        let i = (v ^ xor) & xor;
+        let j = i | (v & (u64::MAX >> 1));
+        Self {
+            key: j.to_be_bytes(),
+        }
+    }
+}
+
+impl Key for Float32 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.key.to_vec()
+    }
+}
+
+impl Key for Float64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.key.to_vec()
+    }
+}
+
+/// Builder to create keys based on several other keys.
+/// For instance, we have a structure:
+/// ```
+/// struct MyStruct(u8, String, u32, Box<f64>);
+/// ```
+/// and we want to store this structure inside [Art](crate::Art) tree. This structure can identified
+/// by first 2 fields: `(u8, String)`. We can create compound key based on them and use it as
+/// tree key.
+/// ```
+/// use art_tree::Art;
+///
+/// struct MyStruct(u8, String, u32, Box<f64>);
+///
+/// let mut art = Art::new();
+/// let key = KeyBuilder::new().append(1).append("abc".to_string()).build();
+/// let val = MyStruct(1, "abc".to_string(), 200, Box::new(0.1));
+/// assert!(art.insert(key.clone(), val));
+/// assert!(art.get(&key).is_some());
+/// ```
+#[repr(transparent)]
+pub struct KeyBuilder {
+    key: ByteString,
+}
+
+impl KeyBuilder {
+    pub fn new() -> Self {
+        Self {
+            key: ByteString { bytes: Vec::new() },
+        }
+    }
+
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            key: ByteString {
+                bytes: Vec::with_capacity(cap),
+            },
+        }
+    }
+
+    pub fn append(mut self, key_part: impl Key) -> Self {
+        self.key.bytes.append(&mut key_part.to_bytes());
+        self
+    }
+
+    pub fn build(self) -> ByteString {
+        self.key
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,22 +32,13 @@ mod scanner;
 
 use crate::scanner::Scanner;
 pub use keys::ByteString;
+pub use keys::*;
 use node::*;
 use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::option::Option::Some;
 use std::rc::Rc;
 use std::{cmp, mem, ptr};
-
-/// Trait represent [Art] key.
-/// Trait define method which convert key into byte comparable sequence. This sequence will be
-/// used to order keys inside tree. [Art] crate has several implementation of [Key] trait inside
-/// `keys` module.
-pub trait Key: Eq + Ord {
-    /// Converts key to byte comparable sequence. This sequence used to represent key inside
-    /// [Art] tree.
-    fn to_bytes(&self) -> Vec<u8>;
-}
 
 /// Adaptive Radix Tree structure.  
 /// [Art] accept keys which can be represented as byte comparable sequence. Keys should implement
@@ -491,8 +482,7 @@ fn common_prefix_len(vec1: &[u8], vec2: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use crate::keys::ByteString;
-    use crate::Art;
+    use crate::{Art, ByteString};
     use rand::prelude::IteratorRandom;
     use rand::seq::SliceRandom;
     use rand::{thread_rng, Rng};
@@ -502,11 +492,23 @@ mod tests {
     fn seq_insert_u8() {
         let mut art = Art::new();
         for i in 0..=u8::MAX {
-            assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+            assert!(art.insert(i, i.to_string()), "{}", i);
         }
 
         for i in 0..=u8::MAX {
-            assert!(matches!(art.get(&ByteString::from(i)), Some(val) if val == &i.to_string()));
+            assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+        }
+    }
+
+    #[test]
+    fn seq_insert_i8() {
+        let mut art = Art::new();
+        for i in i8::MIN..=i8::MAX {
+            assert!(art.insert(i, i.to_string()), "{}", i);
+        }
+
+        for i in i8::MIN..=i8::MAX {
+            assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
         }
     }
 
@@ -514,11 +516,23 @@ mod tests {
     fn seq_insert_u16() {
         let mut art = Art::new();
         for i in 0..=u16::MAX {
-            assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+            assert!(art.insert(i, i.to_string()), "{}", i);
         }
 
         for i in 0..=u16::MAX {
-            assert!(matches!(art.get(&ByteString::from(i)), Some(val) if val == &i.to_string()));
+            assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+        }
+    }
+
+    #[test]
+    fn seq_insert_i16() {
+        let mut art = Art::new();
+        for i in i16::MIN..=i16::MAX {
+            assert!(art.insert(i, i.to_string()), "{}", i);
+        }
+
+        for i in i16::MIN..=i16::MAX {
+            assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
         }
     }
 
@@ -529,12 +543,38 @@ mod tests {
             let start = (u16::MAX as u32 + 1) << (shift * 8);
             let end = start + 10000;
             for i in start..=end {
-                assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+                assert!(art.insert(i, i.to_string()), "{}", i);
             }
             for i in start..=end {
-                assert!(
-                    matches!(art.get(&ByteString::from(i)), Some(val) if val == &i.to_string())
-                );
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn seq_insert_i32() {
+        let mut art = Art::new();
+        for shift in 0..2 {
+            let start = i32::MIN >> (shift * 8);
+            let end = start + 10000;
+            for i in start..=end {
+                assert!(art.insert(i, i.to_string()), "{}", i);
+            }
+            for i in start..=end {
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+            }
+        }
+
+        assert!(art.insert(0, "0".to_string()), "{}", 0);
+
+        for shift in 0..2 {
+            let start = (i16::MAX as i32 + 1) << (shift * 8);
+            let end = start + 10000;
+            for i in start..=end {
+                assert!(art.insert(i, i.to_string()), "{}", i);
+            }
+            for i in start..=end {
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
             }
         }
     }
@@ -546,12 +586,66 @@ mod tests {
             let start = (u32::MAX as u64 + 1) << (shift * 8);
             let end = start + 100_000;
             for i in start..=end {
-                assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+                assert!(art.insert(i, i.to_string()), "{}", i);
             }
             for i in start..=end {
-                assert!(
-                    matches!(art.get(&ByteString::from(i)), Some(val) if val == &i.to_string())
-                );
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn seq_insert_i64() {
+        let mut art = Art::new();
+        for shift in 0..4 {
+            let start = i64::MIN >> (shift * 8);
+            let end = start + 10000;
+            for i in start..=end {
+                assert!(art.insert(i, i.to_string()), "{}", i);
+            }
+            for i in start..=end {
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+            }
+        }
+
+        assert!(art.insert(0, "0".to_string()), "{}", 0);
+
+        for shift in 0..4 {
+            let start = (i32::MAX as i64 + 1) << (shift * 8);
+            let end = start + 10000;
+            for i in start..=end {
+                assert!(art.insert(i, i.to_string()), "{}", i);
+            }
+            for i in start..=end {
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn seq_insert_i128() {
+        let mut art = Art::new();
+        for shift in 0..8 {
+            let start = i128::MIN >> (shift * 8);
+            let end = start + 10000;
+            for i in start..=end {
+                assert!(art.insert(i, i.to_string()), "{}", i);
+            }
+            for i in start..=end {
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
+            }
+        }
+
+        assert!(art.insert(0, "0".to_string()), "{}", 0);
+
+        for shift in 0..8 {
+            let start = (i64::MAX as i128 + 1) << (shift * 8);
+            let end = start + 10000;
+            for i in start..=end {
+                assert!(art.insert(i, i.to_string()), "{}", i);
+            }
+            for i in start..=end {
+                assert!(matches!(art.get(&i), Some(val) if val == &i.to_string()));
             }
         }
     }
@@ -560,12 +654,12 @@ mod tests {
     fn seq_remove_u8() {
         let mut art = Art::new();
         for i in 0..=u8::MAX {
-            assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+            assert!(art.insert(i, i.to_string()), "{}", i);
         }
 
         for i in 0..=u8::MAX {
-            assert!(matches!(art.remove(&ByteString::from(i)), Some(val) if val == i.to_string()));
-            assert!(matches!(art.get(&ByteString::from(i)), None));
+            assert!(matches!(art.remove(&i), Some(val) if val == i.to_string()));
+            assert!(matches!(art.get(&i), None));
         }
     }
 
@@ -573,12 +667,12 @@ mod tests {
     fn seq_remove_u16() {
         let mut art = Art::new();
         for i in 0..=u16::MAX {
-            assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+            assert!(art.insert(i, i.to_string()), "{}", i);
         }
 
         for i in 0..=u16::MAX {
-            assert!(matches!(art.remove(&ByteString::from(i)), Some(val) if val == i.to_string()));
-            assert!(matches!(art.get(&ByteString::from(i)), None));
+            assert!(matches!(art.remove(&i), Some(val) if val == i.to_string()));
+            assert!(matches!(art.get(&i), None));
         }
     }
 
@@ -589,13 +683,11 @@ mod tests {
             let start = (u16::MAX as u32 + 1) << (shift * 8);
             let end = start + 10000;
             for i in start..=end {
-                assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+                assert!(art.insert(i, i.to_string()), "{}", i);
             }
             for i in start..=end {
-                assert!(
-                    matches!(art.remove(&ByteString::from(i)), Some(val) if val == i.to_string())
-                );
-                assert!(matches!(art.get(&ByteString::from(i)), None));
+                assert!(matches!(art.remove(&i), Some(val) if val == i.to_string()));
+                assert!(matches!(art.get(&i), None));
             }
         }
     }
@@ -607,13 +699,11 @@ mod tests {
             let start = (u32::MAX as u64 + 1) << (shift * 8);
             let end = start + 100_000;
             for i in start..=end {
-                assert!(art.insert(ByteString::from(i), i.to_string()), "{}", i);
+                assert!(art.insert(i, i.to_string()), "{}", i);
             }
             for i in start..=end {
-                assert!(
-                    matches!(art.remove(&ByteString::from(i)), Some(val) if val == i.to_string())
-                );
-                assert!(matches!(art.get(&ByteString::from(i)), None));
+                assert!(matches!(art.remove(&i), Some(val) if val == i.to_string()));
+                assert!(matches!(art.get(&i), None));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,14 +39,24 @@ pub use keys::ByteString;
 pub use keys::*;
 use node::*;
 use std::marker::PhantomData;
-use std::ops::{Bound, RangeBounds};
+use std::ops::RangeBounds;
 use std::option::Option::Some;
 use std::rc::Rc;
 use std::{cmp, mem, ptr};
 
-/// Adaptive Radix Tree structure.  
-/// [Art] accept keys which can be represented as byte comparable sequence. Keys should implement
-/// [Key] trait which used to convert key to byte sequence.
+/// Adaptive Radix Tree.  
+///
+/// Radix tree is ordered according to key. Radix tree requires that key to be representable as
+/// comparable by sequence, e.g. key should implement [Key] trait which used to convert it to
+/// byte sequence.
+///
+/// This crate provides [Key] implementations for most commonly used data types:
+/// - unsigned integers(u8, u16, u32, u64, u128)  
+/// - signed integers(i8, i16, i32, i64, i128)  
+/// - floating point numbers through [Float32]/[Float64] types
+/// - [ByteString] for raw byte sequences. It can be used for ASCII strings(UTF-8 strings
+/// will be supported soon)  
+/// - usize
 pub struct Art<K, V> {
     root: Option<TypedNode<K, V>>,
     // to make type !Send and !Sync

--- a/src/node.rs
+++ b/src/node.rs
@@ -314,7 +314,7 @@ impl<V> Node48<V> {
         new_node
     }
 
-    fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = &'a V> + 'a {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = &V> {
         let slice = unsafe { &*slice_from_raw_parts(self.values.as_ptr(), self.values.len()) };
         self.keys.iter().filter_map(move |k| {
             if *k > 0 {
@@ -360,7 +360,9 @@ impl<V> Node<V> for Node256<V> {
     fn drain(mut self) -> Vec<(u8, V)> {
         let mut res = Vec::new();
         for i in 0..self.values.len() {
-            self.values[i].take().map(|v| res.push((i as u8, v)));
+            if let Some(v) = self.values[i].take() {
+                res.push((i as u8, v))
+            }
         }
 
         // emulate that all values was moved out from node before drop

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -378,6 +378,21 @@ mod tests {
         }
 
         assert_eq!(art.iter().count(), all_keys.len());
+
+        let mut art: Art<Float32, String> = Art::new();
+        art.insert(f32::NEG_INFINITY.into(), f32::NEG_INFINITY.to_string());
+        art.insert(f32::MIN.into(), f32::MIN.to_string());
+        art.insert(f32::MIN_POSITIVE.into(), f32::MIN_POSITIVE.to_string());
+        art.insert(f32::MAX.into(), f32::MAX.to_string());
+        art.insert(f32::INFINITY.into(), f32::INFINITY.to_string());
+        art.insert(f32::NAN.into(), f32::NAN.to_string());
+        let mut iter = art.iter();
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f32::MIN.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f32::NEG_INFINITY.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f32::MIN_POSITIVE.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f32::MAX.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f32::INFINITY.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f32::NAN.to_string()));
     }
 
     #[test]
@@ -423,6 +438,21 @@ mod tests {
         }
 
         assert_eq!(art.iter().count(), all_keys.len());
+
+        let mut art: Art<Float64, String> = Art::new();
+        art.insert(f64::NEG_INFINITY.into(), f64::NEG_INFINITY.to_string());
+        art.insert(f64::MIN.into(), f64::MIN.to_string());
+        art.insert(f64::MIN_POSITIVE.into(), f64::MIN_POSITIVE.to_string());
+        art.insert(f64::MAX.into(), f64::MAX.to_string());
+        art.insert(f64::INFINITY.into(), f64::INFINITY.to_string());
+        art.insert(f64::NAN.into(), f64::NAN.to_string());
+        let mut iter = art.iter();
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f64::MIN.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f64::NEG_INFINITY.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f64::MIN_POSITIVE.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f64::MAX.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f64::INFINITY.to_string()));
+        assert!(matches!(iter.next(), Some((_, val)) if val == &f64::NAN.to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Add native support for key types: 
- unsigned integers(u8, u16, u32, u64, u128)
- signed integers(i8, i16, i32, i64, i128)
- usize
- floating point numbers through `Float32`/`Float64` types(to implement `Ord` for them)

`ByteString` type now used only for raw byte sequences and not support conversion from numeric types anymore.
`Art` no more requires keys to be `Ord` in most cases, `Ord` required only for scan operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lagrang/art-rs/1)
<!-- Reviewable:end -->
